### PR TITLE
Build on Ascent

### DIFF
--- a/scripts/olcf_ascent_cmake
+++ b/scripts/olcf_ascent_cmake
@@ -1,0 +1,54 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+source ${SCRIPT_DIR}/set_kokkos_env.sh
+
+rm -f  CMakeCache.txt
+rm -rf CMakeFiles/
+EXTRA_ARGS=("$@")
+ARGS=(
+    -D CMAKE_BUILD_TYPE=Debug
+    -D BUILD_SHARED_LIBS=ON
+    ### COMPILERS AND FLAGS ###
+    -D CMAKE_CXX_FLAGS="-g -lineinfo \
+        -Xcudafe --diag_suppress=conversion_function_not_usable \
+        -Xcudafe --diag_suppress=cc_clobber_ignored \
+        -Xcudafe --diag_suppress=code_is_unreachable"
+    -D DataTransferKit_CXX_FLAGS="-Wall -Wno-shadow -Wpedantic"
+    -D Trilinos_CXX11_FLAGS="-std=c++14 --expt-extended-lambda"
+    -D KOKKOS_ARCH="Power9;Volta70"
+    -D MPI_EXEC="jsrun"
+    -D MPI_EXEC_NUMPROCS_FLAG="-n"
+    -D MPI_EXEC_POST_NUMPROCS_FLAGS="-a1;-c5;-bpacked:5;-g1"
+    ### TPLs ###
+    -D TPL_ENABLE_MPI=ON
+    -D TPL_ENABLE_CUDA=ON
+    -D TPL_ENABLE_BLAS=ON
+    -D TPL_ENABLE_LAPACK=ON
+    -D TPL_ENABLE_Boost=ON
+    -D CMAKE_PREFIX_PATH="${BENCHMARK_ROOT}"
+    ### ETI ###
+    -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION=ON
+    ### PACKAGES CONFIGURATION ###
+    -D Trilinos_ENABLE_ALL_PACKAGES=OFF
+    -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES=OFF
+    -D Trilinos_ENABLE_TESTS=OFF
+    -D Trilinos_ENABLE_EXAMPLES=OFF
+    -D Trilinos_ENABLE_OpenMP=ON
+    -D Trilinos_ENABLE_Tpetra=ON
+        -D Tpetra_INST_COMPLEX_DOUBLE=OFF
+        -D Tpetra_INST_COMPLEX_FLOAT=OFF
+        -D Tpetra_INST_SERIAL=ON
+        -D Tpetra_INST_OPENMP=ON
+        -D Tpetra_INST_CUDA=ON
+    -D Kokkos_ENABLE_OpenMP=ON
+    -D Kokkos_ENABLE_Cuda=ON
+    -D Kokkos_ENABLE_Cuda_UVM=ON
+    -D Kokkos_ENABLE_Cuda_Lambda=ON
+    ### DTK ###
+    -D Trilinos_EXTRA_REPOSITORIES="DataTransferKit"
+    -D Trilinos_ENABLE_DataTransferKit=ON
+        -D DataTransferKit_ENABLE_DBC=ON
+        -D DataTransferKit_ENABLE_TESTS=ON
+        -D DataTransferKit_ENABLE_EXAMPLES=ON
+    )
+cmake "${ARGS[@]}" "${EXTRA_ARGS[@]}" "${TRILINOS_DIR}"


### PR DESCRIPTION
@Rombur @NickRF

modules: `gcc/6.4.0 cuda/9.2.148 boost/1.66.0 cmake/3.12.2 netlib-lapack/3.8.0`

You will need to define the following two env variables:
* `TRILINOS_DIR` pointing to the Trilinos source directory with DataTransferKit symlinked/cloned into it
* You may directly use `BENCHMARK_ROOT=/gpfs/wolf/gen113/proj-shared/qdi/opt/benchmark` unless you really want to build it yourself.